### PR TITLE
Process larger batch sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,4 @@ ASALocalRun/
 
 # Mac OS files
 .DS_Store
+/LocalPreparer/Dfe.Spi.LocalPreparer/appsettings.json

--- a/HistoricalDataLoader/src/Dfe.Spi.HistoricalDataLoader.RegistryLoaderConsoleApp/DocumentLoader.cs
+++ b/HistoricalDataLoader/src/Dfe.Spi.HistoricalDataLoader.RegistryLoaderConsoleApp/DocumentLoader.cs
@@ -122,7 +122,7 @@ namespace Dfe.Spi.HistoricalDataLoader.RegistryLoaderConsoleApp
                 var potentialBatchSize = registeredEntities
                     .Select(SizeOf)
                     .Sum();
-                if (potentialBatchSize >= maxRequestSize)
+                if (potentialBatchSize >= maxRequestSize || registeredEntityDocumentIds.Count > 100)
                 {
                     _logger.Information("Batch would be too large, processing individually");
                     for (var j = 0; j < registeredEntities.Length; j++)


### PR DESCRIPTION
Batches larger than 100 documents cannot be loaded in one go. Process batches larger than 100 document by document instead